### PR TITLE
Make WRValue.asString() safer

### DIFF
--- a/discrete_src/vm.cpp
+++ b/discrete_src/vm.cpp
@@ -293,7 +293,7 @@ void wr_registerLibraryFunction( WRState* w, const char* signature, WR_LIB_CALLB
 #include <stdio.h>
 #endif
 //------------------------------------------------------------------------------
-char* WRValue::asString( char* string ) const
+char* WRValue::asString( char* string, size_t len ) const
 {
 	if ( xtype )
 	{
@@ -306,15 +306,16 @@ char* WRValue::asString( char* string ) const
 			
 			case WR_EX_STRUCT:
 			{
-				strcpy( string, "struct" );
+				strncpy( string, "struct", len );
 				return string;
 			}
 			
 			case WR_EX_ARRAY:
 			{
 				unsigned int s = 0;
-					
-				for( ; s<va->m_size; ++s )
+
+				size_t size = va->m_size > len ? len : va->m_size;
+				for( ; s<size; ++s )
 				{
 					switch( va->m_type)
 					{
@@ -333,12 +334,17 @@ char* WRValue::asString( char* string ) const
 				{
 					WRValue temp;
 					wr_arrayToValue(this, &temp);
-					return temp.asString(string);
+					return temp.asString(string, len );
 				}
 				else
 				{
-					return r->asString(string);
+					return r->asString(string, len );
 				}
+			}
+			case WR_EX_NONE:
+			{
+				strncpy(string, "None", len );
+				break;
 			}
 		}
 	}
@@ -347,17 +353,17 @@ char* WRValue::asString( char* string ) const
 		switch( type )
 		{
 #ifdef WRENCH_SPRINTF_OPERATIONS
-			case WR_INT: { sprintf( string, "%d", i ); break; }
-			case WR_FLOAT: { sprintf( string, "%g", f ); break; }
+			case WR_INT: { snprintf( string, len, "%d", i ); break; }
+			case WR_FLOAT: { snprintf( string, len, "%g", f ); break; }
 #else
 			case WR_INT: 
 			case WR_FLOAT:
 			{
-				string[0] = 0;
+				strncpy(string, len, "");
 				break;
 			}
 #endif
-			case WR_REF: { return r->asString( string ); }
+			case WR_REF: { return r->asString( string, len ); }
 		}
 	}
 	

--- a/discrete_src/wrench.h
+++ b/discrete_src/wrench.h
@@ -43,6 +43,7 @@ This Flag:
 -- increases interpreter size slightly (a K or two)
 
 */
+#include <cstddef>
 #define WRENCH_JUMPTABLE_INTERPRETER
 /***********************************************************************/
 
@@ -437,7 +438,7 @@ struct WRValue
 		}
 */
 	}
-	
+
 	float asFloat() const
 	{
 		if ( type == WR_FLOAT )
@@ -459,9 +460,9 @@ struct WRValue
 		return f;
 	}
 	
-	// string: must point to a buffer long enough to contain the string in
-	// the case value is an array of chars. the pointer will be passed back
-	char* asString( char* string ) const;
+        // string: must point to a buffer long enough to contain at least len bytes.
+        // the pointer will be passed back
+	char* asString( char* string, size_t len ) const;
 
 	//WRValueType getType() { return enumType == WR_REF ? r->getType() : enumType; }
 

--- a/src/wrench.cpp
+++ b/src/wrench.cpp
@@ -6819,7 +6819,7 @@ void wr_registerLibraryFunction( WRState* w, const char* signature, WR_LIB_CALLB
 #include <stdio.h>
 #endif
 //------------------------------------------------------------------------------
-char* WRValue::asString( char* string ) const
+char* WRValue::asString( char* string, size_t len ) const
 {
 	if ( xtype )
 	{
@@ -6832,15 +6832,16 @@ char* WRValue::asString( char* string ) const
 			
 			case WR_EX_STRUCT:
 			{
-				strcpy( string, "struct" );
+				strncpy( string, "struct", len );
 				return string;
 			}
 			
 			case WR_EX_ARRAY:
 			{
 				unsigned int s = 0;
-					
-				for( ; s<va->m_size; ++s )
+
+				size_t size = va->m_size > len ? len : va->m_size;
+				for( ; s<size; ++s )
 				{
 					switch( va->m_type)
 					{
@@ -6859,12 +6860,17 @@ char* WRValue::asString( char* string ) const
 				{
 					WRValue temp;
 					wr_arrayToValue(this, &temp);
-					return temp.asString(string);
+					return temp.asString(string, len );
 				}
 				else
 				{
-					return r->asString(string);
+					return r->asString(string, len );
 				}
+			}
+			case WR_EX_NONE:
+			{
+				strncpy(string, "None", len );
+				break;
 			}
 		}
 	}
@@ -6873,17 +6879,17 @@ char* WRValue::asString( char* string ) const
 		switch( type )
 		{
 #ifdef WRENCH_SPRINTF_OPERATIONS
-			case WR_INT: { sprintf( string, "%d", i ); break; }
-			case WR_FLOAT: { sprintf( string, "%g", f ); break; }
+			case WR_INT: { snprintf( string, len, "%d", i ); break; }
+			case WR_FLOAT: { snprintf( string, len, "%g", f ); break; }
 #else
 			case WR_INT: 
 			case WR_FLOAT:
 			{
-				string[0] = 0;
+				strncpy(string, len, "");
 				break;
 			}
 #endif
-			case WR_REF: { return r->asString( string ); }
+			case WR_REF: { return r->asString( string, len ); }
 		}
 	}
 	

--- a/src/wrench.h
+++ b/src/wrench.h
@@ -44,6 +44,7 @@ This Flag:
 -- increases interpreter size slightly (a K or two)
 
 */
+#include <cstddef>
 #define WRENCH_JUMPTABLE_INTERPRETER
 /***********************************************************************/
 
@@ -438,7 +439,7 @@ struct WRValue
 		}
 */
 	}
-	
+
 	float asFloat() const
 	{
 		if ( type == WR_FLOAT )
@@ -460,9 +461,9 @@ struct WRValue
 		return f;
 	}
 	
-	// string: must point to a buffer long enough to contain the string in
-	// the case value is an array of chars. the pointer will be passed back
-	char* asString( char* string ) const;
+        // string: must point to a buffer long enough to contain at least len bytes.
+        // the pointer will be passed back
+	char* asString( char* string, size_t len ) const;
 
 	//WRValueType getType() { return enumType == WR_REF ? r->getType() : enumType; }
 

--- a/wrench_cli.cpp
+++ b/wrench_cli.cpp
@@ -119,7 +119,7 @@ static void log( WRState* s, const WRValue* argv, const int argn, WRValue& retVa
 	for( int i=0; i<argn; ++i )
 	{
 		char buf[256];
-		printf( "%s", argv[i].asString(buf) );
+		printf( "%s", argv[i].asString(buf, 256) );
 	}
 	printf( "\n" );
 }
@@ -283,7 +283,7 @@ static void emit( WRState* s, const WRValue* argv, const int argn, WRValue& retV
 	if ( argn >= 1 )
 	{
 		char buf[256];
-		((WRstr*)usr)->appendFormat( "%s\n", argv->asString(buf) );
+		((WRstr*)usr)->appendFormat( "%s\n", argv->asString(buf, 256) );
 	}
 }
 
@@ -452,7 +452,7 @@ void log2( WRState* w, const WRValue* argv, const int argn, WRValue& retVal, voi
 	char buf[512];
 	for( int i=0; i<argn; ++i )
 	{
-		printf( "%s", argv[i].asString(buf) );
+		printf( "%s", argv[i].asString(buf, 512) );
 	}
 }
 


### PR DESCRIPTION
The method now requires a buffer length parameter to prevent memory errors