### PR TITLE
fix cross module stack offset bug

### DIFF
--- a/discrete_src/vm/vm.cpp
+++ b/discrete_src/vm/vm.cpp
@@ -876,8 +876,10 @@ debugReturn:
 							if ( (I = import->registry.exists(fhash, false)) )
 							{
 								// import shares our stack, tell it where to find it's args
-								import->stackOffset = (stackTop - stackBase);
+								uint8_t savedOffset = import->stackOffset;
+								import->stackOffset = (uint8_t)(stackTop - context->stack);
 								wr_callFunction( import, I->wrf, stackTop - args, args );
+								import->stackOffset = savedOffset;
 								register0 = stackTop;
 
 								if ( *pc == O_NewObjectTable )
@@ -960,8 +962,10 @@ newObjOut:
 							if ( (register0 = import->registry.exists(fhash, false)) )
 							{
 								// import shares our stack, tell it where to find it's args
-								import->stackOffset = (stackTop - stackBase);
+								uint8_t savedOffset = import->stackOffset;
+								import->stackOffset = (uint8_t)(stackTop - context->stack);
 								wr_callFunction( import, register0->wrf, stackTop - args, args );
+								import->stackOffset = savedOffset;
 								goto CallFunctionByHashAndPop_continue;
 							}
 

--- a/src/wrench.cpp
+++ b/src/wrench.cpp
@@ -11842,8 +11842,10 @@ debugReturn:
 							if ( (I = import->registry.exists(fhash, false)) )
 							{
 								// import shares our stack, tell it where to find it's args
-								import->stackOffset = (stackTop - stackBase);
+								uint8_t savedOffset = import->stackOffset;
+								import->stackOffset = (uint8_t)(stackTop - context->stack);
 								wr_callFunction( import, I->wrf, stackTop - args, args );
+								import->stackOffset = savedOffset;
 								register0 = stackTop;
 
 								if ( *pc == O_NewObjectTable )
@@ -11926,8 +11928,10 @@ newObjOut:
 							if ( (register0 = import->registry.exists(fhash, false)) )
 							{
 								// import shares our stack, tell it where to find it's args
-								import->stackOffset = (stackTop - stackBase);
+								uint8_t savedOffset = import->stackOffset;
+								import->stackOffset = (uint8_t)(stackTop - context->stack);
 								wr_callFunction( import, register0->wrf, stackTop - args, args );
+								import->stackOffset = savedOffset;
 								goto CallFunctionByHashAndPop_continue;
 							}
 


### PR DESCRIPTION
I'm working on a project using wrench, and to get around the number of functions limit I'm compiling things into separate modules and then including them. In doing this I found a bug in the stack offset calls when doing deep cross module calls. I wrote a doctest which proves it, which i've attached (my project uses doctest so this was the most natural place to try it for me, hopefully it at least demonstrates the issue for you). Without the patch in this PR the deep cross module calls fail, and with it they pass, so hopefully I got this all right!

Basically when three or more modules are imported via `wr_import()` and a script in module A calls a function in module B which in turn calls a function in module C, the VM crashes with SIGSEGV. Two-module chains (A calls B) work fine. The crash seems to be caused by incorrect `stackOffset` bookkeeping.

In my testing I proved that:

- 2-module A->B cross-module calls: work perfectly, even under heavy traffic (100+ rounds, loops with 72+ iterations).
- 3-module A->B->C nested calls: immediate SIGSEGV.
- Sequential C++ calls to different cross-module paths (call A->B, then call B->C): second call returns null or crashes.

As far as I can see the issues are:

### Relative offset instead of absolute

`stackBase` is defined as `context->stack + context->stackOffset`. So `stackTop - stackBase` computes the offset *relative to the calling context's frame*, not relative to the start of the shared stack. When A calls B, A's `stackOffset` is typically 0, so `stackTop - stackBase` equals `stackTop - context->stack` and things work.

But when B calls C, B's `stackOffset` is non-zero (it was set when A called B). Now `stackTop - stackBase` gives a smaller value than the actual absolute position in the stack. When C's `wr_callFunction` runs and computes `context->stack + context->stackOffset`, it points to the wrong location -- potentially overlapping B's frame or A's frame -- and reads garbage, causing a SIGSEGV.

### stackOffset not saved/restored

Even if the offset calculation were correct, `import->stackOffset` is overwritten and never restored after `wr_callFunction` returns. If the same imported context is called again later (from a different caller, or in a different part of the execution), it will use the stale `stackOffset` from the previous call, leading to corruption or null returns.

-----
I hope all that makes sense and I got it right! It's my first time actually looking into the internals of wrench rather than just using it, but this bug was causing me some pain and the PR seems to fix it so fingers crossed! I'm not sure if it's appropriate to change it in both the discreet source and the single file versions, but just let me know and I can change it as you like.


[test_wrench_cross_module_globals.cpp](https://github.com/user-attachments/files/25260540/test_wrench_cross_module_globals.cpp)