### PR TITLE
Fixed debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+﻿win32/.vs
+win32/Debug
+win32/wrench/Debug

--- a/discrete_src/debug/client_debug.cpp
+++ b/discrete_src/debug/client_debug.cpp
@@ -62,6 +62,8 @@ void WRDebugClientInterface::load( const uint8_t* byteCode, const int size )
 
 	I->m_comm->send( WrenchPacketScoped(WRD_Load, size, byteCode) );
 
+	WrenchPacketScoped r( I->getPacket() );
+
 	// invalidate source block;
 	g_free( I->m_sourceBlock );
 	I->m_sourceBlock = 0;

--- a/discrete_src/debug/debug.cpp
+++ b/discrete_src/debug/debug.cpp
@@ -151,12 +151,6 @@ void wr_formatStackEntry( const WRValue* v, WRstr& out )
 					break;
 				}
 
-				case WR_EX_DEBUG_BREAK:
-				{
-					out.appendFormat( "EX:DEBUG_BREAK\n" );
-					break;
-				}
-
 				case WR_EX_ITERATOR:
 				{
 					// todo- break out VA

--- a/discrete_src/debug/debug_comm.h
+++ b/discrete_src/debug/debug_comm.h
@@ -44,20 +44,64 @@ public:
 };
 
 //------------------------------------------------------------------------------
-class WrenchDebugLoopbackInterface : public WrenchDebugCommInterface
+class WrenchDebugLoopbackInterface;
+
+class WrenchDebugLoopbackEndpoint : public WrenchDebugCommInterface
 {
 public:
-
-	bool send( WrenchPacket* packet ) { return (*m_queue.addHead() = WrenchPacket::alloc( *packet)) != 0; }
-	WrenchPacket* receive( const int timeoutMilliseconds )
+	WrenchDebugLoopbackEndpoint(SimpleLL<WrenchPacket*>& writeQueue,
+		SimpleLL<WrenchPacket*>& readQueue)
+		: m_writeQueue(writeQueue)
+		, m_readQueue(readQueue)
+		, m_server(nullptr)
 	{
-		WrenchPacket* p = 0;
-		m_queue.popTail( &p );
+	}
+
+	bool send(WrenchPacket* packet) override
+	{
+		WrenchPacket* p = (*m_writeQueue.addHead() = WrenchPacket::alloc(*packet));
+		if (m_server) m_server->tick();
+		return (p != nullptr);
+	}
+
+	WrenchPacket* receive(const int timeoutMilliseconds = 0) override
+	{
+		WrenchPacket* p = nullptr;
+		m_readQueue.popTail(&p);
 		return p;
 	}
 
+	void setServer(WRDebugServerInterface* server) { m_server = server; }
+
 private:
-	SimpleLL<WrenchPacket*> m_queue;
+	SimpleLL<WrenchPacket*>& m_writeQueue;
+	SimpleLL<WrenchPacket*>& m_readQueue;
+	WRDebugServerInterface* m_server;
+};
+
+class WrenchDebugLoopbackInterface : public WrenchDebugCommInterface
+{
+public:
+	WrenchDebugLoopbackInterface()
+		: m_clientEndpoint(m_c2s, m_s2c)
+		, m_serverEndpoint(m_s2c, m_c2s)
+	{
+	}
+
+	WrenchDebugCommInterface* clientInterface() { return &m_clientEndpoint; }
+
+	WrenchDebugCommInterface* serverInterface() { return &m_serverEndpoint; }
+
+	void setServer(WRDebugServerInterface* server)
+	{
+		m_clientEndpoint.setServer(server);
+	}
+
+private:
+	SimpleLL<WrenchPacket*> m_c2s;
+	SimpleLL<WrenchPacket*> m_s2c;
+	WrenchDebugLoopbackEndpoint m_clientEndpoint;
+	WrenchDebugLoopbackEndpoint m_serverEndpoint;
 };
 
 //------------------------------------------------------------------------------

--- a/discrete_src/debug/debugger.cpp
+++ b/discrete_src/debug/debugger.cpp
@@ -43,13 +43,6 @@ void dbprintln( WRContext* c, const WRValue* argv, const int argn, WRValue& retV
 }
 
 //------------------------------------------------------------------------------
-void debugPrint( const char* text )
-{
-	wr_stdout( text, strlen(text) );
-	wr_stdout( "\n", 1 );
-}
-
-//------------------------------------------------------------------------------
 void dbprint( WRContext* c, const WRValue* argv, const int argn, WRValue& retVal, void* usr )
 {
 	for( int i=0; i<argn; ++i )
@@ -152,8 +145,9 @@ bool WrenchDebugClient::init( const char* name, const char* address, const int p
 	else
 	{
 		WrenchDebugLoopbackInterface* loop = new WrenchDebugLoopbackInterface();
-		m_client = new WRDebugClientInterface( loop );
-		m_server = new WRDebugServerInterface( m_w, loop );
+		m_client = new WRDebugClientInterface( loop->clientInterface() );
+		m_server = new WRDebugServerInterface( m_w, loop->serverInterface() );
+		loop->setServer(m_server);
 		m_comm = loop;
 	}
 
@@ -213,6 +207,8 @@ bool WrenchDebugClient::loadSource( const char* name )
 
 	splitNL( sbuf );
 
+	printf( "[%s] ready to run\n", name );
+
 	return true;
 }
 
@@ -224,7 +220,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 	bool state = init( currentName, address, port );
 
 	bool showCodePos = false;
-	bool showCallStack = false;
+	bool showCallSt = false;
 	bool showVars = false;
 
 	char buf[200];
@@ -244,10 +240,10 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 			showCodePosition();
 		}
 
-		if ( showCallStack )
+		if ( showCallSt )
 		{
-			showCallStack = false;
-//			showCallStack();
+			showCallSt = false;
+			showCallStack();
 		}
 		
 		if ( showVars )
@@ -262,11 +258,12 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 			}
 		}
 
-/*
-		char stk[64000] = "null";
-		m_client->getStackDump( stk, 64000 );
+		/*
+		printf("stack dump ------------------------\n");
+		char stk[65536] = "null";
+		m_client->getStackDump( stk, 65536 );
 		printf( "%s\n\n", stk );
-*/
+		*/
 		
 		if ( !state )
 		{
@@ -306,7 +303,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 				printf( "frame [%d]\n", stackLevel );
 			}
 
-			showCallStack = true;
+			showCallSt = true;
 
 			continue;
 		}
@@ -322,11 +319,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 						currentName = *cmd.next();
 					}
 
-					if ( loadSource(currentName) )
-					{
-						printf( "[%s] ready to run\n", currentName.c_str() );
-					}
-					else
+					if ( !loadSource(currentName) )
 					{
 						printf( "[%s] failed to load\n", currentName.c_str() );
 					}
@@ -338,7 +331,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 					m_client->run( toLine );
 
 					showCodePos = true;
-					showCallStack = true;
+					showCallSt = true;
 					showVars = true;
 				}
 				break;
@@ -347,7 +340,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 			case 'l':
 			{
 				showCodePos = true;
-				showCallStack = true;
+				showCallSt = true;
 				showVars = true;
 				break;
 			}
@@ -358,7 +351,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 				{
 					m_client->stepOver();
 					showCodePos = true;
-					showCallStack = true;
+					showCallSt = true;
 					showVars = true;
 					break;
 				}
@@ -369,7 +362,7 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 			{
 				m_client->stepInto();
 				showCodePos = true;
-				showCallStack = true;
+				showCallSt = true;
 				showVars = true;
 				break;
 			}
@@ -394,20 +387,20 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 							if ( *b == bp )
 							{
 								bp = -1;
-								showBreakpoint( bp );
+								showBreakpoint( *b );
 								printf( "removed %d\n", *b );
-								m_breakpoints.popItem( b );
 								m_client->clearBreakpoint( *b );
+								m_breakpoints.popItem( b );
 								break;
 							}
 						}
 
 						if ( bp != -1 )
 						{
-							printf( "added %d\n", bp );
-							*m_breakpoints.addHead() = bp;
-							showBreakpoint( bp );
 							m_client->setBreakpoint( bp );
+							*m_breakpoints.addHead() = bp;
+							printf( "added %d\n", bp );
+							showBreakpoint( bp );
 						}
 					}
 				}
@@ -545,6 +538,13 @@ void WrenchDebugClient::enter( const char* sourceFileName, const char* address, 
 				
 				break;
 			}
+
+			case 'w':
+			{
+				showCallStack();
+
+				break;
+			}
 			
 			case 'q': break;
 
@@ -654,6 +654,11 @@ bool WrenchDebugClient::printVariable( WRstr& str )
 	SimpleLL<WrenchCallStackEntry>* stack = m_client->getCallstack();
 	if ( !stack )
 	{	
+		return false;
+	}
+
+	if (m_currentDepth < 0)
+	{
 		return false;
 	}
 

--- a/discrete_src/debug/packet.cpp
+++ b/discrete_src/debug/packet.cpp
@@ -39,6 +39,7 @@ WrenchPacket::WrenchPacket( const WrenchDebugComm type, const uint32_t payloadSi
 WrenchPacket::WrenchPacket( const int32_t type )
 {
 	memset( (char*)this, 0, sizeof(WrenchPacket) );
+	size = sizeof(WrenchPacket);
 	t = type;
 }
 

--- a/discrete_src/utils/wrench_cli.cpp
+++ b/discrete_src/utils/wrench_cli.cpp
@@ -374,15 +374,17 @@ int main( int argn, char* argv[] )
 	else if ( SimpleArgs::get(argn, argv, "dbg") )
 	{
 		WrenchDebugClient client;
+		char buf[64];
+		char *address = NULL;
 		int port = 0;
-		char address[64];
-		if (SimpleArgs::get(argn, argv, "-port", address, 64))
+		if (SimpleArgs::get(argn, argv, "-address", buf, 64))
 		{
-			port = atoi(address);
+			address = buf;
 		}
-		address[0] = 0;
-		SimpleArgs::get(argn, argv, "-address", address, 64);
-		
+		if (SimpleArgs::get(argn, argv, "-port", buf, 64))
+		{
+			port = atoi(buf);
+		}
 		client.enter( SimpleArgs::get(argn, argv, -1), address, port );
 	}
 #endif

--- a/discrete_src/wrench.h
+++ b/discrete_src/wrench.h
@@ -1112,6 +1112,9 @@ private:
 	WRGCObject(WRGCObject& A);
 };
 
+
+class WRDebugServerInterface;
+
 //------------------------------------------------------------------------------
 struct WRContext
 {
@@ -1197,7 +1200,6 @@ struct WRState
 #endif
 
 struct WrenchPacket;
-class WRDebugServerInterface;
 class WRDebugServerInterfacePrivate;
 class WRDebugClientInterfacePrivate;
 class WrenchDebugCommInterface;


### PR DESCRIPTION
- Fixed wrench_cli.cpp "dbg" option logic
- Fixed client_debug.cpp WRDebugClientInterface::load to read response OK packet
- Removed inexistent WR_EX_DEBUG_BREAK in debug.cpp
- Rewrite Loopback debug interface in debug_comm.h to separate data streams in either directions and remove recursion, also handle debug server "tick"
- Fixed debugger.cpp to handle removing already set breakpoints, show call stack, other small fixes
- Fixed packet.cpp to set valid size for packet without payload
- Fixed wrench.h to build
- Added .gitignore to ignore Windows artifacts

Tested and working on Windows